### PR TITLE
ros/publisher.go: fixed data race in accessing net.Addr.String()

### DIFF
--- a/ros/publisher.go
+++ b/ros/publisher.go
@@ -35,6 +35,7 @@ type defaultPublisher struct {
 	sessionErrorChan   chan error
 	listenerErrorChan  chan error
 	listener           net.Listener
+	listenAddr         string
 	connectCallback    func(SingleSubscriberPublisher)
 	disconnectCallback func(SingleSubscriberPublisher)
 }
@@ -60,6 +61,7 @@ func newDefaultPublisher(logger Logger, nodeId string, nodeApiUri string,
 		panic(err)
 	} else {
 		pub.listener = listener
+		pub.listenAddr = listener.Addr().String()
 	}
 	return pub
 }
@@ -123,7 +125,7 @@ func (pub *defaultPublisher) start(wg *sync.WaitGroup) {
 
 func (pub *defaultPublisher) listenRemoteSubscriber() {
 	logger := pub.logger
-	logger.Debugf("Start listen %s.", pub.listener.Addr().String())
+	logger.Debugf("Start listen %s.", pub.listenAddr)
 	defer func() {
 		logger.Debug("defaultPublisher.listenRemoteSubscriber exit")
 	}()
@@ -158,7 +160,7 @@ func (pub *defaultPublisher) Shutdown() {
 }
 
 func (pub *defaultPublisher) hostAndPort() (string, string) {
-	addr, port, err := net.SplitHostPort(pub.listener.Addr().String())
+	addr, port, err := net.SplitHostPort(pub.listenAddr)
 	if err != nil {
 		// Not reached
 		panic(err)


### PR DESCRIPTION
```
WARNING: DATA RACE
Read at 0x00c42009d669 by goroutine 22:
  net.IP.String()
      /usr/lib/go/src/net/ip.go:279 +0x699
  net.ipEmptyString()
      /usr/lib/go/src/net/ip.go:340 +0x76
  net.(*TCPAddr).String()
      /usr/lib/go/src/net/tcpsock.go:32 +0x71
  github.com/cnord/rosgo/ros.(*defaultPublisher).hostAndPort()
      /home/angri/alba/gopath/src/github.com/cnord/rosgo/ros/publisher.go:161 +0x7a
  github.com/cnord/rosgo/ros.(*defaultNode).requestTopic()
      /home/angri/alba/gopath/src/github.com/cnord/rosgo/ros/node.go:207 +0x536
  github.com/cnord/rosgo/ros.newDefaultNode.func11()
      /home/angri/alba/gopath/src/github.com/cnord/rosgo/ros/node.go:108 +0xb1
  runtime.call128()
      /usr/lib/go/src/runtime/asm_amd64.s:511 +0x51
  reflect.Value.Call()
      /usr/lib/go/src/reflect/value.go:302 +0xc0
  github.com/cnord/rosgo/xmlrpc.(*Handler).ServeHTTP()
      /home/angri/alba/gopath/src/github.com/cnord/rosgo/xmlrpc/xmlrpc.go:560 +0x7d3
  net/http.serverHandler.ServeHTTP()
      /usr/lib/go/src/net/http/server.go:2619 +0xbc
  net/http.(*conn).serve()
      /usr/lib/go/src/net/http/server.go:1801 +0x83b

Previous write at 0x00c42009d669 by main goroutine:
  syscall.anyToSockaddr()
      /usr/lib/go/src/syscall/syscall_linux.go:416 +0x108
  syscall.Getsockname()
      /usr/lib/go/src/syscall/syscall_linux.go:473 +0x105
  net.(*netFD).listenStream()
      /usr/lib/go/src/net/sock_posix.go:185 +0x2cd
  net.socket()
      /usr/lib/go/src/net/sock_posix.go:80 +0x37f
  net.internetSocket()
      /usr/lib/go/src/net/ipsock_posix.go:141 +0x144
  net.listenTCP()
      /usr/lib/go/src/net/tcpsock_posix.go:156 +0xc9
  net.ListenTCP()
      /usr/lib/go/src/net/tcpsock.go:319 +0xe0
  net.Listen()
      /usr/lib/go/src/net/dial.go:592 +0x736
  github.com/cnord/rosgo/ros.listenRandomPort()
      /home/angri/alba/gopath/src/github.com/cnord/rosgo/ros/node.go:50 +0x1e0
  github.com/cnord/rosgo/ros.newDefaultPublisher()
      /home/angri/alba/gopath/src/github.com/cnord/rosgo/ros/publisher.go:59 +0x4c2
  github.com/cnord/rosgo/ros.(*defaultNode).NewPublisherWithCallbacks()
      /home/angri/alba/gopath/src/github.com/cnord/rosgo/ros/node.go:243 +0x58c
  github.com/cnord/rosgo/ros.(*defaultNode).NewPublisher()
      /home/angri/alba/gopath/src/github.com/cnord/rosgo/ros/node.go:227 +0x7c
  // skipped
```