### PR TITLE
Ros service timeout method added

### DIFF
--- a/ros/ros.go
+++ b/ros/ros.go
@@ -82,5 +82,5 @@ type ServiceServer interface {
 type ServiceClient interface {
 	Call(srv Service) error
 	Shutdown()
-	SetDeadline(uint32)
+	SetTimeout(time.Duration)
 }

--- a/ros/ros.go
+++ b/ros/ros.go
@@ -82,4 +82,5 @@ type ServiceServer interface {
 type ServiceClient interface {
 	Call(srv Service) error
 	Shutdown()
+	SetDeadline(uint32)
 }

--- a/ros/service_client.go
+++ b/ros/service_client.go
@@ -17,7 +17,7 @@ type defaultServiceClient struct {
 	srvType   ServiceType
 	masterUri string
 	nodeId    string
-	connDeadline time.Duration
+	connTimeout time.Duration
 }
 
 func newDefaultServiceClient(logger Logger, nodeId string, masterUri string, service string, srvType ServiceType) *defaultServiceClient {
@@ -27,12 +27,12 @@ func newDefaultServiceClient(logger Logger, nodeId string, masterUri string, ser
 	client.srvType = srvType
 	client.masterUri = masterUri
 	client.nodeId = nodeId
-	client.SetDeadline(10)
+	client.SetTimeout(10 * time.Millisecond)
 	return client
 }
 
-func (c *defaultServiceClient) SetDeadline(ms uint32) {
-	c.connDeadline = time.Duration(ms) * time.Millisecond
+func (c *defaultServiceClient) SetTimeout(delay time.Duration) {
+	c.connTimeout = delay
 }
 
 func (c *defaultServiceClient) Call(srv Service) error {
@@ -71,13 +71,13 @@ func (c *defaultServiceClient) Call(srv Service) error {
 	for _, h := range headers {
 		logger.Debugf("  `%s` = `%s`", h.key, h.value)
 	}
-	conn.SetDeadline(time.Now().Add(c.connDeadline))
+	conn.SetDeadline(time.Now().Add(c.connTimeout))
 	if err = writeConnectionHeader(headers, conn); err != nil {
 		return err
 	}
 
 	// 2. Read reponse header
-	conn.SetDeadline(time.Now().Add(c.connDeadline))
+	conn.SetDeadline(time.Now().Add(c.connTimeout))
 	if resHeaders, readErr := readConnectionHeader(conn); readErr != nil {
 		return readErr
 	} else {
@@ -98,30 +98,30 @@ func (c *defaultServiceClient) Call(srv Service) error {
 	_ = srv.ReqMessage().Serialize(&buf)
 	reqMsg := buf.Bytes()
 	size := uint32(len(reqMsg))
-	conn.SetDeadline(time.Now().Add(c.connDeadline))
+	conn.SetDeadline(time.Now().Add(c.connTimeout))
 	if err = binary.Write(conn, binary.LittleEndian, size); err != nil {
 		return err
 	}
 	logger.Debug(len(reqMsg))
-	conn.SetDeadline(time.Now().Add(c.connDeadline))
+	conn.SetDeadline(time.Now().Add(c.connTimeout))
 	if _, err = conn.Write(reqMsg); err != nil {
 		return err
 	}
 
 	// 4. Read OK byte
 	var ok byte
-	conn.SetDeadline(time.Now().Add(c.connDeadline))
+	conn.SetDeadline(time.Now().Add(c.connTimeout))
 	if err = binary.Read(conn, binary.LittleEndian, &ok); err != nil {
 		return err
 	} else {
 		if ok == 0 {
 			var size uint32
-			conn.SetDeadline(time.Now().Add(c.connDeadline))
+			conn.SetDeadline(time.Now().Add(c.connTimeout))
 			if err = binary.Read(conn, binary.LittleEndian, &size); err != nil {
 				return err
 			} else {
 				errMsg := make([]byte, int(size))
-				conn.SetDeadline(time.Now().Add(c.connDeadline))
+				conn.SetDeadline(time.Now().Add(c.connTimeout))
 				if _, err = io.ReadFull(conn, errMsg); err != nil {
 					return err
 				} else {
@@ -132,7 +132,7 @@ func (c *defaultServiceClient) Call(srv Service) error {
 	}
 
 	// 5. Receive response
-	conn.SetDeadline(time.Now().Add(c.connDeadline))
+	conn.SetDeadline(time.Now().Add(c.connTimeout))
 	//logger.Debug("Reading message size...")
 	var msgSize uint32
 	if err = binary.Read(conn, binary.LittleEndian, &msgSize); err != nil {

--- a/ros/service_client.go
+++ b/ros/service_client.go
@@ -12,11 +12,11 @@ import (
 )
 
 type defaultServiceClient struct {
-	logger    Logger
-	service   string
-	srvType   ServiceType
-	masterUri string
-	nodeId    string
+	logger      Logger
+	service     string
+	srvType     ServiceType
+	masterUri   string
+	nodeId      string
 	connTimeout time.Duration
 }
 

--- a/ros/service_client.go
+++ b/ros/service_client.go
@@ -17,6 +17,7 @@ type defaultServiceClient struct {
 	srvType   ServiceType
 	masterUri string
 	nodeId    string
+	connDeadline time.Duration
 }
 
 func newDefaultServiceClient(logger Logger, nodeId string, masterUri string, service string, srvType ServiceType) *defaultServiceClient {
@@ -26,7 +27,12 @@ func newDefaultServiceClient(logger Logger, nodeId string, masterUri string, ser
 	client.srvType = srvType
 	client.masterUri = masterUri
 	client.nodeId = nodeId
+	client.connDeadline = time.Duration(10)
 	return client
+}
+
+func (c *defaultServiceClient) SetDeadline(ms uint32) {
+	c.connDeadline = time.Duration(ms)
 }
 
 func (c *defaultServiceClient) Call(srv Service) error {
@@ -65,13 +71,13 @@ func (c *defaultServiceClient) Call(srv Service) error {
 	for _, h := range headers {
 		logger.Debugf("  `%s` = `%s`", h.key, h.value)
 	}
-	conn.SetDeadline(time.Now().Add(10 * time.Millisecond))
+	conn.SetDeadline(time.Now().Add(c.connDeadline * time.Millisecond))
 	if err = writeConnectionHeader(headers, conn); err != nil {
 		return err
 	}
 
 	// 2. Read reponse header
-	conn.SetDeadline(time.Now().Add(10 * time.Millisecond))
+	conn.SetDeadline(time.Now().Add(c.connDeadline * time.Millisecond))
 	if resHeaders, readErr := readConnectionHeader(conn); readErr != nil {
 		return readErr
 	} else {
@@ -92,30 +98,30 @@ func (c *defaultServiceClient) Call(srv Service) error {
 	_ = srv.ReqMessage().Serialize(&buf)
 	reqMsg := buf.Bytes()
 	size := uint32(len(reqMsg))
-	conn.SetDeadline(time.Now().Add(10 * time.Millisecond))
+	conn.SetDeadline(time.Now().Add(c.connDeadline * time.Millisecond))
 	if err = binary.Write(conn, binary.LittleEndian, size); err != nil {
 		return err
 	}
 	logger.Debug(len(reqMsg))
-	conn.SetDeadline(time.Now().Add(10 * time.Millisecond))
+	conn.SetDeadline(time.Now().Add(c.connDeadline * time.Millisecond))
 	if _, err = conn.Write(reqMsg); err != nil {
 		return err
 	}
 
 	// 4. Read OK byte
 	var ok byte
-	conn.SetDeadline(time.Now().Add(10 * time.Millisecond))
+	conn.SetDeadline(time.Now().Add(c.connDeadline * time.Millisecond))
 	if err = binary.Read(conn, binary.LittleEndian, &ok); err != nil {
 		return err
 	} else {
 		if ok == 0 {
 			var size uint32
-			conn.SetDeadline(time.Now().Add(10 * time.Millisecond))
+			conn.SetDeadline(time.Now().Add(c.connDeadline * time.Millisecond))
 			if err = binary.Read(conn, binary.LittleEndian, &size); err != nil {
 				return err
 			} else {
 				errMsg := make([]byte, int(size))
-				conn.SetDeadline(time.Now().Add(10 * time.Millisecond))
+				conn.SetDeadline(time.Now().Add(c.connDeadline * time.Millisecond))
 				if _, err = io.ReadFull(conn, errMsg); err != nil {
 					return err
 				} else {
@@ -126,7 +132,7 @@ func (c *defaultServiceClient) Call(srv Service) error {
 	}
 
 	// 5. Receive response
-	conn.SetDeadline(time.Now().Add(10 * time.Millisecond))
+	conn.SetDeadline(time.Now().Add(c.connDeadline * time.Millisecond))
 	//logger.Debug("Reading message size...")
 	var msgSize uint32
 	if err = binary.Read(conn, binary.LittleEndian, &msgSize); err != nil {


### PR DESCRIPTION
Added setter SetDeadline to ros.ServiceClient. It allows to change connection timeout during execution of ros.ServiceClient.Call. That could be usefull when passed a heavy data in multilayered request's scheme or when ros is working on a non performance device. 