### PR TITLE
Listen random port simplify

### DIFF
--- a/ros/node.go
+++ b/ros/node.go
@@ -45,7 +45,7 @@ func listenRandomPort(address string) (net.Listener, error) {
 	if listener, err := net.Listen("tcp", addr); err == nil {
 		return listener, nil
 	} else {
-		return nil, fmt.Errorf("listenRandomPort exceeds trial limit.")
+		return nil, fmt.Errorf("listenRandomPort cannot found a free port.")
 	}
 }
 

--- a/ros/node.go
+++ b/ros/node.go
@@ -41,6 +41,7 @@ type defaultNode struct {
 }
 
 func listenRandomPort(address string) (net.Listener, error) {
+	// Let OS give us one of ephemeral port
 	addr := fmt.Sprintf("%s:0", address)
 	if listener, err := net.Listen("tcp", addr); err == nil {
 		return listener, nil

--- a/ros/node.go
+++ b/ros/node.go
@@ -45,7 +45,7 @@ func listenRandomPort(address string) (net.Listener, error) {
 	if listener, err := net.Listen("tcp", addr); err == nil {
 		return listener, nil
 	} else {
-		return nil, fmt.Errorf("listenRandomPort cannot found a free port.")
+		return nil, fmt.Errorf("listenRandomPort cannot found a free port: %s", err.Error())
 	}
 }
 

--- a/ros/node.go
+++ b/ros/node.go
@@ -2,7 +2,6 @@ package ros
 
 import (
 	"fmt"
-	"math/rand"
 	"net"
 	"net/http"
 	"os"
@@ -41,22 +40,13 @@ type defaultNode struct {
 	waitGroup      sync.WaitGroup
 }
 
-func listenRandomPort(address string, trialLimit int) (net.Listener, error) {
-	var listener net.Listener
-	var err error
-	numTrial := 0
-	rand.Seed(time.Now().UnixNano())
-	for numTrial < trialLimit {
-		port := 1024 + rand.Intn(65535-1024)
-		addr := fmt.Sprintf("%s:%d", address, port)
-		listener, err = net.Listen("tcp", addr)
-		if err == nil {
-			return listener, nil
-		} else {
-			numTrial += 1
-		}
+func listenRandomPort(address string) (net.Listener, error) {
+	addr := fmt.Sprintf("%s:0", address)
+	if listener, err := net.Listen("tcp", addr); err == nil {
+		return listener, nil
+	} else {
+		return nil, fmt.Errorf("listenRandomPort exceeds trial limit.")
 	}
-	return nil, fmt.Errorf("listenRandomPort exceeds trial limit.")
 }
 
 func newDefaultNode(name string) *defaultNode {
@@ -86,7 +76,7 @@ func newDefaultNode(name string) *defaultNode {
 	node.masterUri = os.Getenv("ROS_MASTER_URI")
 	logger.Debugf("Master URI = %s", node.masterUri)
 
-	listener, err := listenRandomPort("127.0.0.1", 10)
+	listener, err := listenRandomPort("127.0.0.1")
 	if err != nil {
 		logger.Fatal(err)
 	}

--- a/ros/node.go
+++ b/ros/node.go
@@ -45,6 +45,7 @@ func listenRandomPort(address string, trialLimit int) (net.Listener, error) {
 	var listener net.Listener
 	var err error
 	numTrial := 0
+	rand.Seed(time.Now().UnixNano())
 	for numTrial < trialLimit {
 		port := 1024 + rand.Intn(65535-1024)
 		addr := fmt.Sprintf("%s:%d", address, port)

--- a/ros/publisher.go
+++ b/ros/publisher.go
@@ -57,7 +57,7 @@ func newDefaultPublisher(logger Logger, nodeId string, nodeApiUri string,
 	pub.sessions = list.New()
 	pub.connectCallback = connectCallback
 	pub.disconnectCallback = disconnectCallback
-	if listener, err := listenRandomPort("127.0.0.1", 10); err != nil {
+	if listener, err := listenRandomPort("127.0.0.1"); err != nil {
 		panic(err)
 	} else {
 		pub.listener = listener

--- a/ros/service_server.go
+++ b/ros/service_server.go
@@ -41,7 +41,7 @@ type defaultServiceServer struct {
 func newDefaultServiceServer(node *defaultNode, service string, srvType ServiceType, handler interface{}) *defaultServiceServer {
 	logger := node.logger
 	server := new(defaultServiceServer)
-	if listener, err := listenRandomPort("127.0.0.1", 10); err != nil {
+	if listener, err := listenRandomPort("127.0.0.1"); err != nil {
 		panic(err)
 	} else {
 		if tcpListener, ok := listener.(*net.TCPListener); ok {


### PR DESCRIPTION
The issue could happen when you attempt to restart go-node quickly, due to pseudo-randomization gives the same sequence of random ports.

UPD:
listenRandomPort now gets free port from OS.